### PR TITLE
Invalid XML ouput: small bug fix

### DIFF
--- a/lib/OSM/Objects/Way.php
+++ b/lib/OSM/Objects/Way.php
@@ -62,7 +62,7 @@ class OSM_Objects_Way extends OSM_Objects_Object implements OSM_Objects_IXml {
 		{
 			$xmlStr.= '<nd ref="' . $nodeRef . '" />' . "\n";
 		}
-		$xmlStr.= '</' . $xmlName . '/>';
+		$xmlStr.= '</' . $xmlName . '>';
 
 		return $xmlStr;
 	}


### PR DESCRIPTION
bad slash inserted in the closing way tag in OSM_Objects_Way::asXmlStr()
